### PR TITLE
Fix for gmaps toolbar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -95,6 +95,7 @@ class _MyAppState extends State<MyApp> {
           backgroundColor: Colors.green[700],
         ),
         body: GoogleMap(
+          mapToolbarEnabled: false,
           onMapCreated: _onMapCreated,
           mapType: MapType.normal,
           markers: _createMarker(),


### PR DESCRIPTION
Gör så att tool-baren inte dyker upp när man klickar på marker. Textrutan återstår.